### PR TITLE
content-addressable-union-fs -> hyperfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
   "devDependencies": {},
   "repository": {
     "type": "git",
-    "url": "https://github.com/mafintosh/content-addressable-union-fs.git"
+    "url": "https://github.com/mafintosh/hyperfs.git"
   },
   "author": "Mathias Buus (@mafintosh)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mafintosh/content-addressable-union-fs/issues"
+    "url": "https://github.com/mafintosh/hyperfs/issues"
   },
-  "homepage": "https://github.com/mafintosh/content-addressable-union-fs"
+  "homepage": "https://github.com/mafintosh/hyperfs"
 }


### PR DESCRIPTION
No biggie but should make the link on npmjs.org purdier. I have to start _somewhere_ :grinning: 

![screenshot from 2016-01-17 23 04 55](https://cloud.githubusercontent.com/assets/308049/12380252/cae2006c-bd6e-11e5-96ac-5eac142077e0.png)
